### PR TITLE
Visitor cannot bookmark

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,5 +1,6 @@
 class TutorialsController < ApplicationController
   def show
+    flash[:alert] = 'User must login to bookmark videos' if params[:alert].present?
     tutorial = Tutorial.find(params[:id])
     @facade = TutorialFacade.new(tutorial, params[:video_id])
   end

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -26,7 +26,7 @@
         <% if current_user %>
         <%= button_to 'Bookmark', user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: 'btn btn-outline mb1 teal' %>
         <% else %>
-        <%= link_to 'Bookmark', login_path, class: 'btn btn-outline mb1 teal' %>
+        <%= link_to 'Bookmark', tutorial_path(video_id: @facade.current_video.id, alert: true), class: 'btn btn-outline mb1 teal' %>
         <% end %>
       </div>
     </div>

--- a/spec/features/user/user_can_bookmark_a_video_spec.rb
+++ b/spec/features/user/user_can_bookmark_a_video_spec.rb
@@ -9,7 +9,7 @@ describe 'A registered user' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit tutorial_path(tutorial)
-    
+
     expect {
       click_button 'Bookmark'
            }.to change { UserVideo.count }.by(1)

--- a/spec/features/vistors/visitor_is_asked_to_log_in_when_bookmarking_spec.rb
+++ b/spec/features/vistors/visitor_is_asked_to_log_in_when_bookmarking_spec.rb
@@ -1,14 +1,17 @@
 require 'rails_helper'
 
 describe 'visitor visits video show page' do
-  it 'clicks on the bookmark page and is sent to the log in page' do
+  it 'clicks on the bookmark page and gets a flash message saying to log in' do
     tutorial = create(:tutorial)
     video = create(:video, tutorial_id: tutorial.id)
 
     visit tutorial_path(tutorial)
 
-    click_on 'Bookmark'
+    expect {
+      click_link 'Bookmark'
+    }.to change { UserVideo.count }.by(0)
 
-    expect(current_path).to eq(login_path)
+    expect(current_path).to eq(tutorial_path(tutorial))
+    expect(page).to have_content('User must login to bookmark videos')
   end
 end


### PR DESCRIPTION
Closes #20 
Changed bookmark link path to redirect them back to tutorial show,
Added flash message telling them they need to log in first,
Updated visitor can bookmark feature spec to account for flash message and new path.
